### PR TITLE
Update parameter name to upcase-initials method

### DIFF
--- a/classes/property.yasnippet
+++ b/classes/property.yasnippet
@@ -4,10 +4,10 @@
 # --
 private ${1:String} ${2:name};$0
 
-public $1 get${2:$(upcase-initials text)}() {
+public $1 get${2:$(upcase-initials yas-text)}() {
     return $2;
 }
 
-public void set${2:$(upcase-initials text)}($1 $2) {
+public void set${2:$(upcase-initials yas-text)}($1 $2) {
     this.$2 = $2;
 }


### PR DESCRIPTION
Seems the name in upcase-initials has been changed from text to yas-text
